### PR TITLE
chore(nuxt): mark `typescript` peer dependency as optional

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -24,6 +24,11 @@
   "peerDependencies": {
     "typescript": "*"
   },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@dxup/unimport": "workspace:^",
     "@nuxt/kit": "catalog:",


### PR DESCRIPTION
(otherwise `typescript` gets installed in every nuxt project)