### PR TITLE
fix(nuxt): generate transform sourcemaps when server sourcemaps are eabled

### DIFF
--- a/packages/nuxt/src/module/named-layout-slots/module.ts
+++ b/packages/nuxt/src/module/named-layout-slots/module.ts
@@ -66,6 +66,6 @@ ${Object.values(app.layouts).map((layout) => (
   addBuildPlugin(TransformPlugins({
     layoutDirs,
     pageDirs,
-    sourcemap: !!nuxt.options.sourcemap.client,
+    sourcemap: !!(nuxt.options.sourcemap.client || nuxt.options.sourcemap.server),
   }));
 }


### PR DESCRIPTION
The plugin didn't consider the server-side sourcemap setting.

<img width="1208" height="46" alt="image" src="https://github.com/user-attachments/assets/7728a96a-6fcb-4030-af7b-a891dd755fb0" />

